### PR TITLE
DMOH-26: Added support to set widget tag data-date as "today" or "tomorrow".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `drupal/opening-hours` module.
 
+## [Unreleased]
+
+### Added
+
+* DMOH-26: Added support to set widget tag data-date as "today" or "tomorrow".
+
 ## [8.x-1.0-aplha2]
 
 ### Added

--- a/js/opening-hours-widget.js
+++ b/js/opening-hours-widget.js
@@ -41,7 +41,7 @@
       language: 'en'
     };
 
-    this.s = Object.assign({}, defaults, options);
+    this.settings = Object.assign({}, defaults, options);
     this.items = items;
 
     for (var i = 0; i < items.length; i++) {
@@ -58,7 +58,7 @@
    * @returns {boolean}
    */
   OpeningHours.prototype.init = function () {
-    if (!this.s.endpoint || 0 === this.s.endpoint.length) {
+    if (!this.settings.endpoint || 0 === this.settings.endpoint.length) {
       this.printError('Please provide an API endpoint.');
       return false;
     }
@@ -73,7 +73,7 @@
     }
 
     if (typeof this._current.dataset.language === 'undefined') {
-      this._current.dataset.language = this.s.language;
+      this._current.dataset.language = this.settings.language;
     }
 
     var url = this.constructRequest();
@@ -83,24 +83,24 @@
   /**
    * Create a proper date format (yyyy-mm-dd) from string.
    *
-   * @param {string} d
+   * @param {string} dateString
    *   The data string to parse.
    *
    * @returns {string}
    *   The date in the proper format.
    */
-  OpeningHours.prototype.formattedDate = function (d) {
-    if (d === 'today') {
+  OpeningHours.prototype.formattedDate = function (dateString) {
+    if (dateString === 'today') {
       var today = new Date();
-      d = today.toISOString().slice(0, 10);
+      dateString = today.toISOString().slice(0, 10);
     }
-    if (d === 'tomorrow') {
+    if (dateString === 'tomorrow') {
       var tomorrow = new Date();
       tomorrow.setDate(tomorrow.getDate() + 1);
-      d = tomorrow.toISOString().slice(0, 10);
+      dateString = tomorrow.toISOString().slice(0, 10);
     }
 
-    var date = !d ? new Date() : new Date(d);
+    var date = !dateString ? new Date() : new Date(dateString);
 
     return date.toISOString().slice(0, 10);
   };
@@ -112,7 +112,7 @@
    *   The request URI.
    */
   OpeningHours.prototype.constructRequest = function () {
-    var uri = this.s.endpoint
+    var uri = this.settings.endpoint
         + 'services/'
         + this._current.dataset.service
         + '/channels/'

--- a/js/opening-hours-widget.js
+++ b/js/opening-hours-widget.js
@@ -90,8 +90,19 @@
    *   The date in the proper format.
    */
   OpeningHours.prototype.formattedDate = function (d) {
+    if (d === 'today') {
+      var today = new Date();
+      d = today.toISOString().slice(0, 10);
+    }
+    if (d === 'tomorrow') {
+      var tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      d = tomorrow.toISOString().slice(0, 10);
+    }
+
     var date = !d ? new Date() : new Date(d);
-    return date.toISOString().slice(0,10);
+
+    return date.toISOString().slice(0, 10);
   };
 
   /**

--- a/opening_hours.module
+++ b/opening_hours.module
@@ -18,6 +18,7 @@ function opening_hours_theme($existing, $type, $theme, $path) {
         'service_id' => NULL,
         'channel_id' => NULL,
         'language' => NULL,
+        'date' => NULL,
       ],
     ],
   ];

--- a/templates/opening-hours-widget.html.twig
+++ b/templates/opening-hours-widget.html.twig
@@ -8,10 +8,18 @@
  * - service_id : The opening hours Service ID.
  * - channel_id : The opening hours Channel ID.
  * - language : The language to get the output in.
+ * - date : The date to show the widget for.
  *
  * @see template_preprocess_vg_social_link()
  *
  * @ingroup themeable
  */
 #}
-<div class="openinghours openinghours--{{ type }} openinghours-widget" data-service="{{ service_id }}" data-channel="{{ channel_id }}" data-type="{{ type }}" data-language="{{ language }}"></div>
+<div
+  class="openinghours openinghours--{{ type }} openinghours-widget"
+  data-service="{{ service_id }}"
+  data-channel="{{ channel_id }}"
+  data-type="{{ type }}"
+  data-language="{{ language }}"
+  {% if date %} data-date="{{ date }}"{% endif %}
+></div>


### PR DESCRIPTION
When pages are created they are cached in the Drupal backend. 

To avoid showing cached pages with the "today" or tomorrow date hardcoded in the HTML support for "today" and "tomorrow" dates is added to the widget javascript.

It is now supported to set `data-date="today"` or `data-date="tomorrow"` when adding the openin hours widget tags to html output.