### PR TITLE
Add missing token info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All Notable changes to `drupal/opening-hours` module.
 
+## [Unreleased]
+
+* DMOH-56 : Added missing tokens.
+
 ## [8.x-1.1]
 
 **IMPORTANT : From now on, an API key is required due to a change in the API

--- a/opening_hours.module
+++ b/opening_hours.module
@@ -36,3 +36,42 @@ function opening_hours_theme($existing, $type, $theme, $path) {
 function template_preprocess_opening_hours_widget(&$variables) {
   $variables['widget_id'] = Html::getUniqueId('opening_hours');
 }
+
+/**
+ * Implements hook_token_info_alter().
+ *
+ * Add the missing token info for automatically detected tokens.
+ */
+function opening_hours_token_info_alter(&$info) {
+  $entities = \Drupal::service('entity_field.manager')->getFieldMap();
+  foreach ($entities as $entity_key => $entity) {
+    foreach ($entity as $field_key => $field) {
+      if ($field['type'] !== 'opening_hours' ) {
+        continue;
+      }
+
+      $token_key = sprintf('%s-%s', $entity_key, $field_key);
+      $info['tokens'][$token_key]['service'] = [
+        'name' => t('Opening Hours: Service ID'),
+        'description' => t('The service record ID.'),
+      ];
+      $info['tokens'][$token_key]['service_label'] = [
+        'name' => t('Opening Hours: Service label'),
+        'description' => t('The service label.'),
+      ];
+      $info['tokens'][$token_key]['channel'] = [
+        'name' => t('Opening Hours: Channel ID'),
+        'description' => t('The channel record ID.'),
+      ];
+      $info['tokens'][$token_key]['channel_label'] = [
+        'name' => t('Opening Hours: Channel label'),
+        'description' => t('The channel label.'),
+      ];
+      $info['tokens'][$token_key]['broken'] = [
+        'name' => t('Opening Hours: Broken link'),
+        'description' => t('Indicates if the service/channel link no longer exists in the Opening Hours platform.'),
+      ];
+    }
+  }
+}
+


### PR DESCRIPTION
Implement hook_token_info_alter() to add the missing token info for the opening_hours field:

<img width="775" alt="Schermafbeelding 2020-02-10 om 15 17 16" src="https://user-images.githubusercontent.com/1823998/74157661-f3b6f000-4c18-11ea-9766-571f785392c8.png">
