### PR TITLE
SGD8-1614: Fixed error handling while populating the widget.

### DIFF
--- a/js/opening-hours.binding.js
+++ b/js/opening-hours.binding.js
@@ -22,9 +22,11 @@
           'endpoint': settings.openingHours.endpoint,
           'endpoint_key': settings.openingHours.endpoint_key,
           'language': settings.openingHours.language,
-          'error' : function (request) {
-            var elem = getClosest(request.element, '.field');
-            elem.parentNode.removeChild(elem);
+          'error' : function (item) {
+            var elem = getClosest(item, '.openinghours-wrapper');
+            if (elem) {
+              elem.parentNode.removeChild(elem);
+            }
           }
         };
 

--- a/js/opening-hours.binding.js
+++ b/js/opening-hours.binding.js
@@ -24,7 +24,6 @@
           'language': settings.openingHours.language,
           'error' : function (item) {
             var elem = getClosest(item, '.openinghours-wrapper');
-            console.debug('hidden', item, elem);
             if (elem && elem.parentNode) {
               elem.parentNode.removeChild(elem);
             }

--- a/js/opening-hours.binding.js
+++ b/js/opening-hours.binding.js
@@ -24,7 +24,8 @@
           'language': settings.openingHours.language,
           'error' : function (item) {
             var elem = getClosest(item, '.openinghours-wrapper');
-            if (elem) {
+            console.debug('hidden', item, elem);
+            if (elem && elem.parentNode) {
               elem.parentNode.removeChild(elem);
             }
           }

--- a/js/opening-hours.item.js
+++ b/js/opening-hours.item.js
@@ -178,13 +178,14 @@ OpeningHoursItem.prototype.print = function (data) {
 };
 
 /**
- * Print an error to the page.
+ * Print an error to the console and optionally execute the error option.
  *
  * @param {string} message
  *   The error message to print.
  */
 OpeningHoursItem.prototype.printError = function (message) {
   console.error(message);
-  var error = '<span class="error">Error: ' + message + '</span>';
-  this.print(this.element, error);
+  if (this.options.error) {
+    this.options.error(this.element);
+  }
 };


### PR DESCRIPTION
Instead of trying to print the error message inside the opening hours widget.
We now allow passing a custom error handler.

In our implementation: the error handler will remove the entire template (.openinghours-wrapper) from the DOM.