### PR TITLE
PHP-81: Add support for PHP 8 + update opening hours service

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,14 +2,16 @@ version: "2"
 
 prepare:
   fetch:
-    - url: "https://raw.githubusercontent.com/digipolisgent/ci_config-files-and-scripts/master/php/drupal8/.phpmd.xml"
-      path: ".phpmd.xml"
-    - url: "https://raw.githubusercontent.com/digipolisgent/ci_config-files-and-scripts/master/php/drupal8/.csslintrc"
+    - url: "https://raw.githubusercontent.com/district09/ci_config-files-and-scripts/master/php/drupal8/.csslintrc"
       path: ".csslintrc"
-    - url: "https://raw.githubusercontent.com/digipolisgent/ci_config-files-and-scripts/master/php/drupal8/.eslintrc.json"
+    - url: "https://raw.githubusercontent.com/district09/ci_config-files-and-scripts/master/php/drupal8/.eslintrc.json"
       path: ".eslintrc.json"
-    - url: "https://raw.githubusercontent.com/digipolisgent/ci_config-files-and-scripts/master/php/drupal8/.eslintignore"
+    - url: "https://raw.githubusercontent.com/district09/ci_config-files-and-scripts/master/php/drupal8/.eslintignore"
       path: ".eslintignore"
+    - url: "https://raw.githubusercontent.com/district09/php_package_qa-drupal/1.x/configs/phpcs.xml"
+      path: ".phpcs.xml"
+    - url: "https://raw.githubusercontent.com/district09/php_package_qa-drupal/1.x/configs/phpmd.xml"
+      path: ".phpmd.xml"
 
 checks:
   argument-count:
@@ -46,7 +48,7 @@ plugins:
   phpcodesniffer:
     enabled: true
     config:
-      standard: "phpcs.xml"
+      standard: ".phpcs.xml"
   phpmd:
     enabled: true
     config:
@@ -55,7 +57,7 @@ plugins:
         - inc
         - module
         - install
-      rulesets: "phpmd.xml"
+      rulesets: ".phpmd.xml"
   csslint:
     enabled: true
   eslint:

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,15 @@
 # Ignore the module lock file.
 /composer.lock
 
-# Ignore the vendor directory.
+# Ignore vendor directories.
 /vendor
 /node_modules
 
-# Ignore build artifacts
+# Ignore build artifacts.
 /build
-
-# QA Drupal.
+/.phpunit.result.cache
 /*.local.*
 /*.qa-drupal.*
-/.phpunit.result.cache
+
+# Ignore binary translation files.
+*.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,48 @@
-dist: bionic
 language: php
+sudo: false
 
 php:
+  - 7.4
+  - 8.0
   - 8.1
 
 cache:
   directories:
     - $HOME/.composer/cache
 
+env:
+  matrix:
+    - DRUPAL=9.3
+    - DRUPAL=9.4
+
 jobs:
   fast_finish: true
 
 before_install:
-  # Update composer to latest v2.
+  # Update composer.
   - composer self-update --2
   - composer --version
 
-  # Update SQLite.
-  - sudo echo "deb http://archive.ubuntu.com/ubuntu focal main restricted universe multiverse" >> /etc/apt/sources.list
-  - sudo apt-get update
-  - sudo apt-get -y install sqlite3/focal
+  # Configure the authentication mechanisms.
+  - composer config -ga github-oauth.github.com $GITHUB_TOKEN
+  - composer config -ga http-basic.digipolis.repo.repman.io token $REPMAN_TOKEN
 
-  # Disable sending out e-mails.
-  - echo 'sendmail_path = /bin/true' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  # Require Drupal core.
+  - composer require -n --no-update --sort-packages --dev drupal/core:~$DRUPAL.0
 
-  # Configure the repository authentication mechanisms.
-  - if [ "${GITHUB_TOKEN}" != "" ]; then composer config github-oauth.github.com ${GITHUB_TOKEN}; fi
-  - if [ "${REPMAN_TOKEN}" != "" ]; then composer config --global --auth http-basic.digipolis.repo.repman.io token ${REPMAN_TOKEN}; fi
-
-  # Get the CodeClimate test reporter.
+  # Get and run the Code Climate test reporter.
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 
 install:
-  - touch .env.local
   - composer install -n --no-progress
 
 script:
   - vendor/bin/grumphp run -n
 
 after_script:
-  # Send the coverage report to the CodeClimate test reporter.
+  # Run the Code Climate test reporter.
   - ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT
 
   # Get and run the SonarQube scanner.
@@ -55,6 +56,7 @@ after_script:
     -Dsonar.login=$SONAR_LOGIN
     -Dsonar.projectKey=$SONAR_PROJECT_KEY
     -Dsonar.projectName="$SONAR_PROJECT_NAME"
+    -Dsonar.sources=.
     -Dsonar.tests=tests
-    -Dsonar.exclusions=**/tests/**/*
+    -Dsonar.exclusions=**/build/**/*,**/vendor/**/*,**/tests/**/*
     -Dsonar.php.coverage.reportPaths=build/logs/clover.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All Notable changes to `drupal/opening-hours` module.
 
 ## [Unreleased]
 
-### Updated
-
-- Update qa-drupal.
-
 ### Fixed
 
 - Fix code issues.
@@ -15,6 +11,12 @@ All Notable changes to `drupal/opening-hours` module.
 ### Changed
 
 - Change minimal drupal version to 9.3.
+- Change Client service creation to a factory.
+
+### Updated
+
+- Update qa-drupal.
+- Update stadgent/services-opening-hours package to 2.x.
 
 ## [1.4.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All Notable changes to `drupal/opening-hours` module.
 
+## [Unreleased]
+
+### Updated
+
+- Update qa-drupal.
+
+### Fixed
+
+- Fix code issues.
+
+### Changed
+
+- Change minimal drupal version to 9.3.
+
 ## [1.4.1]
 
 ### Changed
@@ -236,4 +250,4 @@ for the same widget.
 [8.x-1.0-alpha3]: https://github.com/StadGent/drupal_module_opening-hours/compare/8.x-1.0-alpha2...8.x-1.0-alpha3
 [8.x-1.0-alpha2]: https://github.com/StadGent/drupal_module_opening-hours/compare/8.x-1.0-alpha1...8.x-1.0-alpha2
 [8.x-1.0-alpha1]: https://github.com/StadGent/drupal_module_opening-hours/releases/tag/8.x-1.0-alpha1
-[Unreleased]: https://github.com/StadGent/drupal_module_opening-hours/compare/master...develop
+[Unreleased]: https://github.com/StadGent/drupal_module_opening-hours/compare/main...develop

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "stadgent/services-opening-hours": "^2.0"
     },
     "require-dev": {
-        "digipolisgent/qa-drupal": "^1.7",
+        "digipolisgent/qa-drupal": "^1.7.1",
         "drush/drush": "^11"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         "source": "https://github.com/StadGent/drupal_module_opening-hours"
     },
     "require": {
-        "php": "^8.1",
-        "drupal/core": "^9.4",
+        "php": "^7.4 || ^8.0",
+        "drupal/core": "^9.3",
         "stadgent/services-opening-hours": "^1.3"
     },
     "require-dev": {
-        "digipolisgent/qa-drupal": "^1.5",
+        "digipolisgent/qa-drupal": "^1.7",
         "drush/drush": "^11"
     },
     "minimum-stability": "dev",
@@ -50,10 +50,12 @@
     },
     "scripts": {
         "post-install-cmd": "vendor/bin/grumphp git:init",
-        "coverage": "vendor/bin/phpunit --configuration=phpunit-coverage.xml",
-        "grumphp": "vendor/bin/grumphp run --ansi",
-        "phpcs": "vendor/bin/phpcs -p --colors",
-        "phpstan": "vendor/bin/phpstan analyse --level=7 ./src",
-        "phpunit": "vendor/bin/phpunit"
+        "coverage": "vendor/bin/phpunit --configuration=phpunit.qa-drupal.xml --coverage-html build/coverage",
+        "grumphp": "vendor/bin/grumphp run -n",
+        "phpcpd": "vendor/bin/grumphp run --tasks=phpcpd",
+        "phpcs": "vendor/bin/grumphp run --tasks=phpcs",
+        "phpmd": "vendor/bin/grumphp run --tasks=phpmd",
+        "phpstan": "vendor/bin/grumphp run --tasks=phpstan",
+        "phpunit": "vendor/bin/phpunit --configuration=phpunit.qa-drupal.xml"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "stadgent/services-opening-hours": "^2.0"
     },
     "require-dev": {
-        "digipolisgent/qa-drupal": "^1.7.1",
+        "digipolisgent/qa-drupal": "^1.7.2",
         "drush/drush": "^11"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "drupal/core": "^9.3",
-        "stadgent/services-opening-hours": "^1.3"
+        "stadgent/services-opening-hours": "^2.0"
     },
     "require-dev": {
         "digipolisgent/qa-drupal": "^1.7",

--- a/opening_hours.info.yml
+++ b/opening_hours.info.yml
@@ -4,8 +4,7 @@ description: 'Integrates the Opening Hours platform functionality.'
 package: 'Digipolis'
 configure: opening_hours.admin_config
 
-core: '8.x'
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9.3
 
 'interface translation project': opening_hours
 'interface translation server pattern': modules/contrib/%project/translations/%language.po

--- a/opening_hours.services.yml
+++ b/opening_hours.services.yml
@@ -1,7 +1,8 @@
 services:
   opening_hours.client:
-    class: Drupal\opening_hours\Services\ClientService
+    factory: [ 'Drupal\opening_hours\Services\ClientFactory', 'create' ]
     arguments: [ '@config.factory' ]
+    class: StadGent\Services\OpeningHours\Client\Client
   opening_hours.service:
     class: StadGent\Services\OpeningHours\Service\Service\ServiceService
     factory: Drupal\opening_hours\Services\ServiceFactory::createServiceService

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -80,13 +80,16 @@ class ConfigForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
-    if (!UrlHelper::isValid($form_state->getValue('endpoint'), TRUE)) {
+    $endpointIsvalid = UrlHelper::isValid($form_state->getValue('endpoint'), TRUE);
+
+    if (!$endpointIsvalid) {
       $form_state->setErrorByName(
         'endpoint',
         $this->t('Provide an absolute URL.')
       );
     }
-    else {
+
+    if ($endpointIsvalid) {
       $form_state->setValue(
         'endpoint',
         rtrim($form_state->getValue('endpoint'), '/') . '/'

--- a/src/Plugin/Field/FieldFormatter/LabelFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/LabelFormatter.php
@@ -76,6 +76,8 @@ class LabelFormatter extends FormatterBase {
    * {@inheritdoc}
    */
   public function settingsForm(array $form, FormStateInterface $form_state) {
+    $element = [];
+
     $element['label_format'] = [
       '#title' => $this->t('Format'),
       '#description' => $this->t('Create a label by combining the available data.'),

--- a/src/Plugin/Field/FieldFormatter/WidgetFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/WidgetFormatter.php
@@ -24,10 +24,9 @@ class WidgetFormatter extends FormatterBase {
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $element = [];
-
-    $types = new WidgetTypes();
-
+    $widgets = [];
     $preview_widget = FALSE;
+    $types = new WidgetTypes();
 
     if ($this->getSetting('preview_widget_type')) {
       $preview_widget = [
@@ -86,6 +85,7 @@ class WidgetFormatter extends FormatterBase {
   public function settingsForm(array $form, FormStateInterface $form_state) {
     $types = new WidgetTypes();
 
+    $element = [];
     $element['widget_type'] = [
       '#title' => $this->t('Type'),
       '#type' => 'select',

--- a/src/Plugin/views/filter/Broken.php
+++ b/src/Plugin/views/filter/Broken.php
@@ -20,12 +20,9 @@ class Broken extends BooleanOperator {
     $this->ensureMyTable();
     $fieldName = sprintf('%s.%s', $this->tableAlias, $this->realField);
 
-    if (empty($this->value)) {
-      $where = sprintf('(%s = 0 OR %s IS NULL)', $fieldName, $fieldName);
-    }
-    else {
-      $where = sprintf('%s <> 0', $fieldName);
-    }
+    $where = empty($this->value)
+      ? sprintf('(%s = 0 OR %s IS NULL)', $fieldName, $fieldName)
+      : sprintf('%s <> 0', $fieldName);
 
     /** @var \Drupal\views\Plugin\views\query\Sql $query */
     $query = $this->query();

--- a/src/Services/ClientFactory.php
+++ b/src/Services/ClientFactory.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\opening_hours\Services;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use GuzzleHttp\Client as GuzzleClient;
-use StadGent\Services\OpeningHours\Client\Client as StadGentClient;
+use StadGent\Services\OpeningHours\Client\Client;
 use StadGent\Services\OpeningHours\Configuration\Configuration;
 
 /**
@@ -12,7 +14,7 @@ use StadGent\Services\OpeningHours\Configuration\Configuration;
  *
  * @package Drupal\opening_hours\Services
  */
-class ClientService extends StadGentClient {
+final class ClientFactory {
 
   /**
    * Class constructor.
@@ -20,7 +22,7 @@ class ClientService extends StadGentClient {
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory.
    */
-  public function __construct(ConfigFactoryInterface $config_factory) {
+  public static function create(ConfigFactoryInterface $config_factory): Client {
     $config = $config_factory->get('opening_hours.settings');
 
     $configuration = new Configuration(
@@ -30,7 +32,7 @@ class ClientService extends StadGentClient {
 
     $guzzleClient = new GuzzleClient(['base_uri' => $configuration->getUri()]);
 
-    parent::__construct($guzzleClient, $configuration);
+    return new Client($guzzleClient, $configuration);
   }
 
 }

--- a/src/Services/ServiceFactory.php
+++ b/src/Services/ServiceFactory.php
@@ -1,11 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\opening_hours\Services;
 
 use StadGent\Services\OpeningHours\Channel;
 use StadGent\Services\OpeningHours\ChannelOpeningHours;
 use StadGent\Services\OpeningHours\ChannelOpeningHoursHtml;
+use StadGent\Services\OpeningHours\Client\Client;
 use StadGent\Services\OpeningHours\Service;
+use StadGent\Services\OpeningHours\Service\Channel\ChannelServiceInterface;
+use StadGent\Services\OpeningHours\Service\Channel\OpeningHoursHtmlServiceInterface;
+use StadGent\Services\OpeningHours\Service\Channel\OpeningHoursServiceInterface;
+use StadGent\Services\OpeningHours\Service\Service\ServiceServiceInterface;
 
 /**
  * Factory to create the different Opening Hours Services.
@@ -17,52 +24,52 @@ class ServiceFactory {
   /**
    * Create the Service service.
    *
-   * @param \Drupal\opening_hours\Services\ClientService $client
+   * @param \StadGent\Services\OpeningHours\Client\Client $client
    *   The client service.
    *
-   * @return \StadGent\Services\OpeningHours\Service\Service\ServiceService
+   * @return \StadGent\Services\OpeningHours\Service\Service\ServiceServiceInterface
    *   The Service Service.
    */
-  public static function createServiceService(ClientService $client) {
+  public static function createServiceService(Client $client): ServiceServiceInterface {
     return Service::create($client);
   }
 
   /**
    * Create the Channel service.
    *
-   * @param \Drupal\opening_hours\Services\ClientService $client
+   * @param \StadGent\Services\OpeningHours\Client\Client $client
    *   The client service.
    *
-   * @return \StadGent\Services\OpeningHours\Service\Channel\ChannelService
+   * @return \StadGent\Services\OpeningHours\Service\Channel\ChannelServiceInterface
    *   The Channel service.
    */
-  public static function createChannelService(ClientService $client) {
+  public static function createChannelService(Client $client): ChannelServiceInterface {
     return Channel::create($client);
   }
 
   /**
    * Create the Channel OpeningHours service.
    *
-   * @param \Drupal\opening_hours\Services\ClientService $client
+   * @param \StadGent\Services\OpeningHours\Client\Client $client
    *   The client service.
    *
-   * @return \StadGent\Services\OpeningHours\Service\Channel\OpeningHoursService
+   * @return \StadGent\Services\OpeningHours\Service\Channel\OpeningHoursServiceInterface
    *   The Channel Opening Hours service.
    */
-  public static function createChannelOpeningHoursService(ClientService $client) {
+  public static function createChannelOpeningHoursService(Client $client): OpeningHoursServiceInterface {
     return ChannelOpeningHours::create($client);
   }
 
   /**
    * Create the Channel OpeningHours HTML service.
    *
-   * @param \Drupal\opening_hours\Services\ClientService $client
+   * @param \StadGent\Services\OpeningHours\Client\Client $client
    *   The client service.
    *
-   * @return \StadGent\Services\OpeningHours\Service\Channel\OpeningHoursHtmlService
+   * @return \StadGent\Services\OpeningHours\Service\Channel\OpeningHoursHtmlServiceInterface
    *   The Channel Opening Hours HTML service.
    */
-  public static function createChannelOpeningHoursHtmlService(ClientService $client) {
+  public static function createChannelOpeningHoursHtmlService(Client $client): OpeningHoursHtmlServiceInterface {
     return ChannelOpeningHoursHtml::create($client);
   }
 


### PR DESCRIPTION
### Fixed

- Fix code issues.

### Changed

- Change minimal drupal version to 9.3.
- Change Client service creation to a factory.

### Updated

- Update qa-drupal.
- Update stadgent/services-opening-hours package to 2.x.