### PR TITLE
SPOS-237: Change widget tab labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `drupal/opening-hours` module.
 
+## [Unreleased]
+
+### Changed
+
+* Change widget tab labels.
+
 ## [2.0.0]
 
 ### Fixed

--- a/opening_hours.info.yml
+++ b/opening_hours.info.yml
@@ -1,7 +1,7 @@
 name: 'Opening Hours'
 type: module
 description: 'Integrates the Opening Hours platform functionality.'
-package: 'Digipolis'
+package: 'District09'
 configure: opening_hours.admin_config
 
 core_version_requirement: ^9.3

--- a/src/Plugin/Field/FieldFormatter/WidgetTypes.php
+++ b/src/Plugin/Field/FieldFormatter/WidgetTypes.php
@@ -75,12 +75,12 @@ class WidgetTypes {
    */
   public function getToggleList() {
     return [
-      self::OPEN_NOW => new TranslatableMarkup('now'),
-      self::DAY => new TranslatableMarkup('this day'),
-      self::WEEK => new TranslatableMarkup('week overview'),
-      self::WEEK_FROM_NOW => new TranslatableMarkup('week overview'),
-      self::MONTH => new TranslatableMarkup('month overview'),
-      self::YEAR => new TranslatableMarkup('this year'),
+      self::OPEN_NOW => new TranslatableMarkup('Now'),
+      self::DAY => new TranslatableMarkup('This day'),
+      self::WEEK => new TranslatableMarkup('Week overview'),
+      self::WEEK_FROM_NOW => new TranslatableMarkup('This week'),
+      self::MONTH => new TranslatableMarkup('This month'),
+      self::YEAR => new TranslatableMarkup('This year'),
     ];
   }
 

--- a/translations/general.pot
+++ b/translations/general.pot
@@ -3,6 +3,7 @@
 # LANGUAGE translation of Drupal (general)
 # Copyright YEAR NAME <EMAIL@ADDRESS>
 # Generated from files:
+#  modules/contrib/opening_hours/opening_hours.module: n/a
 #  modules/contrib/opening_hours/opening_hours.install: n/a
 #  modules/contrib/opening_hours/opening_hours.info.yml: n/a
 #  modules/contrib/opening_hours/opening_hours.links.menu.yml: n/a
@@ -21,7 +22,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2019-02-28 08:43+0100\n"
+"POT-Creation-Date: 2022-11-29 10:42+0100\n"
 "PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
 "Last-Translator: NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
@@ -30,19 +31,59 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: modules/contrib/opening_hours/opening_hours.install:18
+#: modules/contrib/opening_hours/opening_hours.module:55
+msgid "Opening Hours: Service ID"
+msgstr ""
+
+#: modules/contrib/opening_hours/opening_hours.module:56
+msgid "The service record ID."
+msgstr ""
+
+#: modules/contrib/opening_hours/opening_hours.module:59
+msgid "Opening Hours: Service label"
+msgstr ""
+
+#: modules/contrib/opening_hours/opening_hours.module:60
+msgid "The service label."
+msgstr ""
+
+#: modules/contrib/opening_hours/opening_hours.module:63
+msgid "Opening Hours: Channel ID"
+msgstr ""
+
+#: modules/contrib/opening_hours/opening_hours.module:64
+msgid "The channel record ID."
+msgstr ""
+
+#: modules/contrib/opening_hours/opening_hours.module:67
+msgid "Opening Hours: Channel label"
+msgstr ""
+
+#: modules/contrib/opening_hours/opening_hours.module:68
+msgid "The channel label."
+msgstr ""
+
+#: modules/contrib/opening_hours/opening_hours.module:71
+msgid "Opening Hours: Broken link"
+msgstr ""
+
+#: modules/contrib/opening_hours/opening_hours.module:72
+msgid "Indicates if the service/channel link no longer exists in the Opening Hours platform."
+msgstr ""
+
+#: modules/contrib/opening_hours/opening_hours.install:19
 msgid "Installed"
 msgstr ""
 
-#: modules/contrib/opening_hours/opening_hours.install:25
+#: modules/contrib/opening_hours/opening_hours.install:26
 msgid "Not found"
 msgstr ""
 
-#: modules/contrib/opening_hours/opening_hours.install:28
+#: modules/contrib/opening_hours/opening_hours.install:29
 msgid "The <a href=\"@opening_hours\" target=\"_blank\">opening hours widget</a> plugin is missing. See <a href=\"@readme\">README.md</a> for instructions on how to download and extract it."
 msgstr ""
 
-#: modules/contrib/opening_hours/opening_hours.info.yml:0 modules/contrib/opening_hours/opening_hours.links.menu.yml:0 modules/contrib/opening_hours/opening_hours.routing.yml:0 modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9 modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:21
+#: modules/contrib/opening_hours/opening_hours.info.yml:0 modules/contrib/opening_hours/opening_hours.links.menu.yml:0 modules/contrib/opening_hours/opening_hours.routing.yml:0 modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11 modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:21
 msgid "Opening Hours"
 msgstr ""
 
@@ -50,8 +91,8 @@ msgstr ""
 msgid "Integrates the Opening Hours platform functionality."
 msgstr ""
 
-#: modules/contrib/opening_hours/opening_hours.info.yml:0 modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9
-msgid "Web services"
+#: modules/contrib/opening_hours/opening_hours.info.yml:0
+msgid "District09"
 msgstr ""
 
 #: modules/contrib/opening_hours/opening_hours.links.menu.yml:0
@@ -106,103 +147,103 @@ msgstr ""
 msgid "This will enable caching of the responses from the API."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Form/ConfigForm.php:86
+#: modules/contrib/opening_hours/src/Form/ConfigForm.php:88
 msgid "Provide an absolute URL."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:131 modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:54 modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11
 msgid "Broken"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:131
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:54
 msgid "OK"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:157
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:82
 msgid "Format"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:158
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:83
 msgid "Create a label by combining the available data."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:167
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:92
 msgid "The service ID"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:168
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:93
 msgid "The service label"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:169
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:94
 msgid "The channel ID"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:170
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:95
 msgid "The channel label"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:171
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:96
 msgid "Is the link between the field and the backend broken."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:184
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:109
 msgid "Format: %format"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:14
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:10
 msgid "Labels"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:167
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:90
 msgid "Type"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:174
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:97
 msgid "Alternative type"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:175
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:98
 msgid "Provides an alternative widget type to the visitor."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:178;187
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:101;110
 msgid "None"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:183
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:106
 msgid "Preview type"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:184
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:107
 msgid "Provides a preview widget type to the visitor."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:192
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:115
 msgid "Display title"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:193
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:116
 msgid "Displays the title of the channel when checked."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:199
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:122
 msgid "Display all channels in one widget."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:217
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:140
 msgid "Show as %type widget"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:221
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:144
 msgid "Alternative widget: %type"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:226
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:149
 msgid "Preview widget: %type"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:13
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:9
 msgid "Widget"
 msgstr ""
 
@@ -231,78 +272,86 @@ msgid "Year"
 msgstr ""
 
 #: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:78
-msgid "now"
+msgid "Now"
 msgstr ""
 
 #: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:79
-msgid "this day"
+msgid "This day"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:80;81
-msgid "week overview"
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:80
+msgid "Week overview"
+msgstr ""
+
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:81
+msgid "This week"
 msgstr ""
 
 #: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:82
-msgid "month overview"
+msgid "This month"
 msgstr ""
 
 #: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:83
-msgid "this year"
+msgid "This year"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11
 msgid "Adds a field to select the Service and its Channel to show its opening hours for."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9 modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:163
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11
+msgid "Web services"
+msgstr ""
+
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11 modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:139
 msgid "Service"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11
 msgid "Service label"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9 modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:176
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11 modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:152
 msgid "Channel"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11
 msgid "Channel label"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:153
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:129
 msgid "Opening hours"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:154
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:130
 msgid "Select a Service and one of its Channels to link this item with Opening Hours."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:179
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:155
 msgid "Select first a Service"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:185
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:161
 msgid "- Select -"
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:274
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:252
 msgid "Service does not exists."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:283
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:261
 msgid "Service is required when Channel is set."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:291
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:269
 msgid "Channel is required when Service is set."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:300
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:278
 msgid "Channel does not exists for this Service."
 msgstr ""
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:407;434
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:385;412
 msgid "API returned : @message"
 msgstr ""
 

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -17,26 +17,70 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2019-02-28 08:43+0100\n"
-"PO-Revision-Date: 2019-02-28 08:44+0100\n"
-"Last-Translator: Peter Decuyper <peter.decuyper@digipolis.gent>\n"
-"Language-Team: Digipolis <tbweb@gent.be>\n"
+"POT-Creation-Date: 2022-11-29 10:42+0100\n"
+"PO-Revision-Date: 2022-11-29 11:12+0100\n"
+"Last-Translator: Peter Decuyper <peter.decuyper@district09.gent>\n"
+"Language-Team: District09 <tbweb@gent.be>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.2.1\n"
+"X-Generator: Poedit 3.2\n"
 
-#: modules/contrib/opening_hours/opening_hours.install:18
+#: modules/contrib/opening_hours/opening_hours.module:55
+msgid "Opening Hours: Service ID"
+msgstr "Openingsuren: Service ID"
+
+#: modules/contrib/opening_hours/opening_hours.module:56
+msgid "The service record ID."
+msgstr "De service record ID."
+
+#: modules/contrib/opening_hours/opening_hours.module:59
+msgid "Opening Hours: Service label"
+msgstr "Openingsuren: Service label"
+
+#: modules/contrib/opening_hours/opening_hours.module:60
+msgid "The service label."
+msgstr "De service label."
+
+#: modules/contrib/opening_hours/opening_hours.module:63
+msgid "Opening Hours: Channel ID"
+msgstr "Openingsuren: Kanaal ID"
+
+#: modules/contrib/opening_hours/opening_hours.module:64
+msgid "The channel record ID."
+msgstr "De kanaal record ID."
+
+#: modules/contrib/opening_hours/opening_hours.module:67
+msgid "Opening Hours: Channel label"
+msgstr "Openingsuren: Kanaal label"
+
+#: modules/contrib/opening_hours/opening_hours.module:68
+msgid "The channel label."
+msgstr "Het kanaal label."
+
+#: modules/contrib/opening_hours/opening_hours.module:71
+msgid "Opening Hours: Broken link"
+msgstr "Openingsuren: Gebroken link"
+
+#: modules/contrib/opening_hours/opening_hours.module:72
+msgid ""
+"Indicates if the service/channel link no longer exists in the Opening Hours "
+"platform."
+msgstr ""
+"Indicatie wanneer een service/kanaal link niet meer bestaat in het "
+"Openingsuren platform."
+
+#: modules/contrib/opening_hours/opening_hours.install:19
 msgid "Installed"
 msgstr "Geïnstalleerd"
 
-#: modules/contrib/opening_hours/opening_hours.install:25
+#: modules/contrib/opening_hours/opening_hours.install:26
 msgid "Not found"
 msgstr "Niet gevonden"
 
-#: modules/contrib/opening_hours/opening_hours.install:28
+#: modules/contrib/opening_hours/opening_hours.install:29
 msgid ""
 "The <a href=\"@opening_hours\" target=\"_blank\">opening hours widget</a> "
 "plugin is missing. See <a href=\"@readme\">README.md</a> for instructions on "
@@ -49,7 +93,7 @@ msgstr ""
 #: modules/contrib/opening_hours/opening_hours.info.yml:0
 #: modules/contrib/opening_hours/opening_hours.links.menu.yml:0
 #: modules/contrib/opening_hours/opening_hours.routing.yml:0
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11
 #: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:21
 msgid "Opening Hours"
 msgstr "Openingsuren"
@@ -59,9 +103,8 @@ msgid "Integrates the Opening Hours platform functionality."
 msgstr "Integreert het openingsuren platform."
 
 #: modules/contrib/opening_hours/opening_hours.info.yml:0
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9
-msgid "Web services"
-msgstr "Webservices"
+msgid "District09"
+msgstr "District09"
 
 #: modules/contrib/opening_hours/opening_hours.links.menu.yml:0
 msgid "Configure the Opening Hours service."
@@ -121,104 +164,104 @@ msgstr "Caching inschakelen"
 msgid "This will enable caching of the responses from the API."
 msgstr "Dit zal de caching inschakelen op de resultaten van de API."
 
-#: modules/contrib/opening_hours/src/Form/ConfigForm.php:86
+#: modules/contrib/opening_hours/src/Form/ConfigForm.php:88
 msgid "Provide an absolute URL."
 msgstr "Voorzie een absolute URL."
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:131
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:54
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11
 msgid "Broken"
 msgstr "Defect"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:131
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:54
 msgid "OK"
 msgstr "OK"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:157
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:82
 msgid "Format"
 msgstr "Formaat"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:158
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:83
 msgid "Create a label by combining the available data."
 msgstr "Maak een label door de beschikbare gegevens te combineren."
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:167
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:92
 msgid "The service ID"
 msgstr "De service ID"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:168
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:93
 msgid "The service label"
 msgstr "De service label"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:169
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:94
 msgid "The channel ID"
 msgstr "De kanaal ID"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:170
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:95
 msgid "The channel label"
 msgstr "Het kanaal label"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:171
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:96
 msgid "Is the link between the field and the backend broken."
 msgstr "Is de link tussen het veld en de backend defect."
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:184
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:109
 msgid "Format: %format"
 msgstr "Formaat: %format"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:14
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/LabelFormatter.php:10
 msgid "Labels"
 msgstr "Labels"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:167
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:90
 msgid "Type"
 msgstr "Type"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:174
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:97
 msgid "Alternative type"
 msgstr "Alternatief type"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:175
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:98
 msgid "Provides an alternative widget type to the visitor."
 msgstr "Voorzie een alternatieve widget voor de bezoeker."
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:178;187
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:101;110
 msgid "None"
 msgstr "Geen"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:183
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:106
 msgid "Preview type"
 msgstr "Preview type"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:184
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:107
 msgid "Provides a preview widget type to the visitor."
 msgstr "Voorzie een preview widget voor de bezoeker."
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:192
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:115
 msgid "Display title"
 msgstr "Toon titel"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:193
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:116
 msgid "Displays the title of the channel when checked."
 msgstr "Toont de titel van het kanaal wanneer aangevinkt."
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:199
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:122
 msgid "Display all channels in one widget."
 msgstr "Toont alle kanalen in 1 widget."
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:217
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:140
 msgid "Show as %type widget"
 msgstr "Toon als %type widget"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:221
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:144
 msgid "Alternative widget: %type"
 msgstr "Alternatieve widget: %type"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:226
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:149
 msgid "Preview widget: %type"
 msgstr "Voorvertoning widget: %type"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:13
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetFormatter.php:9
 msgid "Widget"
 msgstr "Widget"
 
@@ -247,26 +290,30 @@ msgid "Year"
 msgstr "Jaar"
 
 #: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:78
-msgid "now"
-msgstr "nu"
+msgid "Now"
+msgstr "Nu"
 
 #: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:79
-msgid "this day"
-msgstr "deze dag"
+msgid "This day"
+msgstr "Deze dag"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:80;81
-msgid "week overview"
-msgstr "weekoverzicht"
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:80
+msgid "Week overview"
+msgstr "Weekoverzicht"
+
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:81
+msgid "This week"
+msgstr "Deze week"
 
 #: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:82
-msgid "month overview"
-msgstr "maandoverzicht"
+msgid "This month"
+msgstr "Deze maand"
 
 #: modules/contrib/opening_hours/src/Plugin/Field/FieldFormatter/WidgetTypes.php:83
-msgid "this year"
-msgstr "dit jaar"
+msgid "This year"
+msgstr "Dit jaar"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11
 msgid ""
 "Adds a field to select the Service and its Channel to show its opening hours "
 "for."
@@ -274,29 +321,33 @@ msgstr ""
 "Voegt een veld toe om de dienst en het kanaal te selecteren om de "
 "openingsuren hiervan te kunnen tonen."
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:163
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11
+msgid "Web services"
+msgstr "Webservices"
+
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:139
 msgid "Service"
 msgstr "Dienst"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11
 msgid "Service label"
 msgstr "Service label"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:176
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:152
 msgid "Channel"
 msgstr "Kanaal"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:9
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldType/OpeningHoursItem.php:11
 msgid "Channel label"
 msgstr "Kanaal label"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:153
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:129
 msgid "Opening hours"
 msgstr "Openingsuren"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:154
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:130
 msgid ""
 "Select a Service and one of its Channels to link this item with Opening "
 "Hours."
@@ -304,33 +355,36 @@ msgstr ""
 "Selecteer een dienst en één van zijn kanalen om deze te verbinden met zijn "
 "openingsuren."
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:179
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:155
 msgid "Select first a Service"
 msgstr "Selecteer eerst een Dienst"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:185
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:161
 msgid "- Select -"
 msgstr "- Selecteer -"
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:274
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:252
 msgid "Service does not exists."
 msgstr "Dienst bestaat niet."
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:283
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:261
 msgid "Service is required when Channel is set."
 msgstr "Dienst is verplicht om een kanaal te selecteren."
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:291
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:269
 msgid "Channel is required when Service is set."
 msgstr "Kanaal is verplicht wanneer een Dienst is geselecteerd."
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:300
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:278
 msgid "Channel does not exists for this Service."
 msgstr "Kanaal bastaat niet voor deze Dienst."
 
-#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:407;434
+#: modules/contrib/opening_hours/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php:385;412
 msgid "API returned : @message"
 msgstr "API retourneerde ; @message"
+
+#~ msgid "month overview"
+#~ msgstr "maandoverzicht"
 
 #~ msgid "Placeholders"
 #~ msgstr "Token"


### PR DESCRIPTION
Change the opening hours widget tabs so they have the same label as used on the City of Ghent website.

## Description

The correct (default) labels are "This week" & "This month" instead of "week overview", "month overview".

## Motivation and Context

As these are the default labels, we should stop overwriting them on all site instances where the Opening hours module is used.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing 
  functionality to change).

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.
- [x] I have read the **CONTRIBUTING** document.
