### PR TITLE
DMOH-59: Add support for Drupal 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: php
 sudo: false
 
 php:
-  - 7.4
-  - 8.0
   - 8.1
 
 cache:
@@ -12,8 +10,9 @@ cache:
 
 env:
   matrix:
-    - DRUPAL=9.3
     - DRUPAL=9.4
+    - DRUPAL=9.5
+    - DRUPAL=10.0
 
 jobs:
   fast_finish: true
@@ -44,19 +43,3 @@ script:
 after_script:
   # Run the Code Climate test reporter.
   - ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT
-
-  # Get and run the SonarQube scanner.
-  - SONAR_PROJECT_NAME="Drupal $(composer config name | cut -d / -f 2)"
-  - SONAR_PROJECT_KEY=web:$(echo "$TRAVIS_REPO_SLUG" | cut -d / -f 2)
-  - curl -L https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/4.3.0.2102/sonar-scanner-cli-4.3.0.2102.jar > sonar-scanner.jar
-  - "[ -d tests ] || mkdir tests"
-  - >
-    java -jar sonar-scanner.jar
-    -Dsonar.host.url=https://sonarqube.stad.gent
-    -Dsonar.login=$SONAR_LOGIN
-    -Dsonar.projectKey=$SONAR_PROJECT_KEY
-    -Dsonar.projectName="$SONAR_PROJECT_NAME"
-    -Dsonar.sources=.
-    -Dsonar.tests=tests
-    -Dsonar.exclusions=**/build/**/*,**/vendor/**/*,**/tests/**/*
-    -Dsonar.php.coverage.reportPaths=build/logs/clover.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All Notable changes to `drupal/opening-hours` module.
 
+## [2.2.0]
+
+### Added
+
+* DMOH-59: Add support for Drupal 10.
+
+### Changed
+
+* DMOH-59: Change minimal Drupal version to 9.4 or 10.0.
+* DMOH-59: Change minimal PHP version to 8.1.
+
 ## [2.1.0]
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         "source": "https://github.com/StadGent/drupal_module_opening-hours"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
-        "drupal/core": "^9.3",
+        "php": "^8.1",
+        "drupal/core": "^9.4 || ^10.0",
         "stadgent/services-opening-hours": "^2.0"
     },
     "require-dev": {
-        "digipolisgent/qa-drupal": "^1.7.2",
+        "digipolisgent/qa-drupal": "^2.0",
         "drush/drush": "^11"
     },
     "minimum-stability": "dev",
@@ -56,6 +56,6 @@
         "phpcs": "vendor/bin/grumphp run --tasks=phpcs",
         "phpmd": "vendor/bin/grumphp run --tasks=phpmd",
         "phpstan": "vendor/bin/grumphp run --tasks=phpstan",
-        "phpunit": "vendor/bin/phpunit --configuration=phpunit.qa-drupal.xml"
+        "phpunit": "vendor/bin/phpunit --no-logging --no-coverage --configuration=phpunit.qa-drupal.xml"
     }
 }

--- a/js/opening-hours.binding.js
+++ b/js/opening-hours.binding.js
@@ -15,7 +15,7 @@
     attach: function (context, settings) {
       var self = this;
 
-      var items = $('.openinghours-widget', context).once('openingHoursWidget');
+      var items = $(once('openingHoursWidget', '.openinghours-widget', context));
 
       if (items.length) {
         var options = {

--- a/opening_hours.info.yml
+++ b/opening_hours.info.yml
@@ -4,7 +4,7 @@ description: 'Integrates the Opening Hours platform functionality.'
 package: 'District09'
 configure: opening_hours.admin_config
 
-core_version_requirement: ^9.3
+core_version_requirement: ^9.4 || ^10
 
 'interface translation project': opening_hours
 'interface translation server pattern': modules/contrib/%project/translations/%language.po

--- a/opening_hours.libraries.yml
+++ b/opening_hours.libraries.yml
@@ -14,6 +14,6 @@ widget:
     js/opening-hours.binding.js: {}
   dependencies:
     - core/jquery
-    - core/jquery.once
+    - core/once
     - core/drupalSettings
     - opening_hours/library


### PR DESCRIPTION
Update the module so it can be used with Drupal 10.

## Description

- Change minimal Drupal version to 9.4 or 10.0.
- Change minimal PHP version to 8.1.
- Fix deprecated usage of jQuery.once.

## How Has This Been Tested?

- GrumPHP & TravisCI.
- Tested in actual website.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.
- [x] I have read the **CONTRIBUTING** document.
