### PR TITLE
DMOH-60: D11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: jammy
 language: php
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 
 env:
   matrix:
-    - DRUPAL=10.0
+    - DRUPAL=10.3
     - DRUPAL=11.0
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: php
 sudo: false
 
 php:
-  - 8.1
+  - 8.3
+  - 8.4
 
 cache:
   directories:
@@ -10,9 +11,8 @@ cache:
 
 env:
   matrix:
-    - DRUPAL=9.4
-    - DRUPAL=9.5
     - DRUPAL=10.0
+    - DRUPAL=11.0
 
 jobs:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
   matrix:
     - DRUPAL=10.3
     - DRUPAL=11.0
+  global:
+    - XDEBUG_MODE=coverage
 
 jobs:
   fast_finish: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All Notable changes to `drupal/opening-hours` module.
 ### Added
 
 * DMOH-60: Add Drupal 11 support.
+* Add distro to travis to prevent failing tests.
+
+### Changed
+
+* Change travis min php version to 8.3 and 8.4.
+* Change travis min drupal version to 10.3 and 11.0.
 
 ## [2.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All Notable changes to `drupal/opening-hours` module.
 
-## [unreleased]
+## [2.2.1]
 
 ### Fixed
 
@@ -258,6 +258,7 @@ for the same widget.
 * DMOH-20: Added the opening hours field type.
 * DMOH-21: Added the opening hours field widget.
 
+[2.2.1]: https://github.com/StadGent/drupal_module_opening-hours/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/StadGent/drupal_module_opening-hours/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/StadGent/drupal_module_opening-hours/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/StadGent/drupal_module_opening-hours/compare/1.5.0...2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All Notable changes to `drupal/opening-hours` module.
 
-## [Unreleased]
+## [2.3.0]
 
 ### Added
 
@@ -270,6 +270,7 @@ for the same widget.
 * DMOH-20: Added the opening hours field type.
 * DMOH-21: Added the opening hours field widget.
 
+[2.3.0]: https://github.com/StadGent/drupal_module_opening-hours/compare/2.2.1...2.3.0
 [2.2.1]: https://github.com/StadGent/drupal_module_opening-hours/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/StadGent/drupal_module_opening-hours/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/StadGent/drupal_module_opening-hours/compare/2.0.0...2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `drupal/opening-hours` module.
 
+## [Unreleased]
+
+### Added
+
+* DMOH-60: Add Drupal 11 support.
+
 ## [2.2.1]
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "stadgent/services-opening-hours": "^2.0"
     },
     "require-dev": {
-        "digipolisgent/qa-drupal": "^2.0 || ^3.0 || ^4.0",
+        "digipolisgent/qa-drupal": "^2.0 || ^4.0",
         "drush/drush": "^11 || ^12 || ^13"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^8.1",
-        "drupal/core": "^9.4 || ^10.0 || ^11",
+        "drupal/core": "^10.0 || ^11",
         "stadgent/services-opening-hours": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^8.1",
-        "drupal/core": "^10.0 || ^11",
+        "drupal/core": "^10.3 || ^11",
         "stadgent/services-opening-hours": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "stadgent/services-opening-hours": "^2.0"
     },
     "require-dev": {
-        "digipolisgent/qa-drupal": "^2.0",
-        "drush/drush": "^11"
+        "digipolisgent/qa-drupal": "^2.0 || ^3.0 || ^4.0",
+        "drush/drush": "^11 || ^12"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -41,7 +41,7 @@
     "extra": {
         "drush": {
             "services": {
-                "drush.services.yml": "^11"
+                "drush.services.yml": "^11 || ^12"
             }
         },
         "grumphp": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^8.1",
-        "drupal/core": "^9.4 || ^10.0",
+        "drupal/core": "^9.4 || ^10.0 || ^11",
         "stadgent/services-opening-hours": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "digipolisgent/qa-drupal": "^2.0 || ^3.0 || ^4.0",
-        "drush/drush": "^11 || ^12"
+        "drush/drush": "^11 || ^12 || ^13"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/opening_hours.info.yml
+++ b/opening_hours.info.yml
@@ -4,7 +4,7 @@ description: 'Integrates the Opening Hours platform functionality.'
 package: 'District09'
 configure: opening_hours.admin_config
 
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^9.4 || ^10 || ^11
 
 'interface translation project': opening_hours
 'interface translation server pattern': modules/contrib/%project/translations/%language.po

--- a/opening_hours.info.yml
+++ b/opening_hours.info.yml
@@ -4,7 +4,7 @@ description: 'Integrates the Opening Hours platform functionality.'
 package: 'District09'
 configure: opening_hours.admin_config
 
-core_version_requirement: ^9.4 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 'interface translation project': opening_hours
 'interface translation server pattern': modules/contrib/%project/translations/%language.po

--- a/opening_hours.install
+++ b/opening_hours.install
@@ -20,18 +20,16 @@ function opening_hours_requirements($phase) {
 
     if (file_exists(DRUPAL_ROOT . '/libraries/opening-hours-widget/dist/opening-hours-widget.min.js')) {
       $requirements['opening_hours']['severity'] = REQUIREMENT_OK;
+      return $requirements;
     }
-    else {
-      // Required opening_hours library wasn't found; abort installation.
-      $requirements['opening_hours']['value'] = t('Not found');
 
-      // Provide a download link to the opening_hours jQuery plugin.
-      $requirements['opening_hours']['description'] = t('The <a href="@opening_hours" target="_blank">opening hours widget</a> plugin is missing. See <a href="@readme">README.md</a> for instructions on how to download and extract it.', [
-        '@opening_hours' => 'https://github.com/StadGent/npm_package_opening-hours-widget',
-        '@readme' => '/' . \Drupal::service('extension.list.module')->getPath('opening_hours') . '/README.md',
-      ]);
-      $requirements['opening_hours']['severity'] = REQUIREMENT_ERROR;
-    }
+    // Required opening_hours library wasn't found; abort installation.
+    $requirements['opening_hours']['value'] = t('Not found');
+    $requirements['opening_hours']['description'] = t('The <a href="@opening_hours" target="_blank">opening hours widget</a> plugin is missing. See <a href="@readme">README.md</a> for instructions on how to download and extract it.', [
+      '@opening_hours' => 'https://github.com/StadGent/npm_package_opening-hours-widget',
+      '@readme' => '/' . \Drupal::service('extension.list.module')->getPath('opening_hours') . '/README.md',
+    ]);
+    $requirements['opening_hours']['severity'] = REQUIREMENT_ERROR;
   }
 
   return $requirements;
@@ -39,6 +37,10 @@ function opening_hours_requirements($phase) {
 
 /**
  * Update the openinghours field: add service & channel name + broken fields.
+ *
+ * @SuppressWarnings("PHPMD.CyclomaticComplexity")
+ * @SuppressWarnings("PHPMD.NPathComplexity")
+ * @SuppressWarnings("PHPMD.LongVariable")
  */
 function opening_hours_update_8101() {
   $columns_to_add = ['service_label', 'channel_label', 'broken'];
@@ -124,7 +126,8 @@ function opening_hours_update_8101() {
       }
       if ($table_mapping->allowsSharedTableStorage($field_storage_definition)) {
         $key = "$entity_type_id.field_storage_definitions";
-        if ($definitions = $entity_definitions_installed->get($key)) {
+        $definitions = $entity_definitions_installed->get($key);
+        if ($definitions) {
           $definitions[$field_name] = $field_storage_definition;
           $entity_definitions_installed->set($key, $definitions);
         }

--- a/src/Commands/SyncCommands.php
+++ b/src/Commands/SyncCommands.php
@@ -35,7 +35,7 @@ final class SyncCommands extends DrushCommands {
    */
   public function __construct(
     SyncService $syncService,
-    EntityTypeManagerInterface $entityTypeManager
+    EntityTypeManagerInterface $entityTypeManager,
   ) {
     parent::__construct();
 

--- a/src/Element/OpeningHoursWidget.php
+++ b/src/Element/OpeningHoursWidget.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Provides the opening_hours_widget element.
  *
- * @RenderElementBase("opening_hours_widget")
+ * @RenderElement("opening_hours_widget")
  */
 class OpeningHoursWidget extends RenderElementBase implements ContainerFactoryPluginInterface {
 

--- a/src/Element/OpeningHoursWidget.php
+++ b/src/Element/OpeningHoursWidget.php
@@ -4,15 +4,15 @@ namespace Drupal\opening_hours\Element;
 
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Render\Element\RenderElement;
+use Drupal\Core\Render\Element\RenderElementBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides the opening_hours_widget element.
  *
- * @RenderElement("opening_hours_widget")
+ * @RenderElementBase("opening_hours_widget")
  */
-class OpeningHoursWidget extends RenderElement implements ContainerFactoryPluginInterface {
+class OpeningHoursWidget extends RenderElementBase implements ContainerFactoryPluginInterface {
 
   /**
    * The opening hours configuration.
@@ -37,7 +37,7 @@ class OpeningHoursWidget extends RenderElement implements ContainerFactoryPlugin
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    ImmutableConfig $opening_hours_config
+    ImmutableConfig $opening_hours_config,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -6,6 +6,7 @@ use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -21,9 +22,11 @@ class ConfigForm extends ConfigFormBase {
    *   The factory for configuration objects.
    * @param \Drupal\Core\StringTranslation\TranslationInterface $stringTranslation
    *   The String translations.
+   * @param \Drupal\Core\Config\TypedConfigManagerInterface $typedConfigManager
+   *   The Typed configuration manager.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, TranslationInterface $stringTranslation) {
-    parent::__construct($config_factory);
+  public function __construct(ConfigFactoryInterface $config_factory, TranslationInterface $stringTranslation, TypedConfigManagerInterface $typedConfigManager) {
+    parent::__construct($config_factory, $typedConfigManager);
     $this->setStringTranslation($stringTranslation);
   }
 
@@ -33,7 +36,8 @@ class ConfigForm extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
-      $container->get('string_translation')
+      $container->get('string_translation'),
+      $container->get('config.typed')
     );
   }
 

--- a/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php
+++ b/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php
@@ -21,8 +21,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * A widget bar.
  *
- * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings("PHPMD.ExcessiveClassComplexity")
+ * @SuppressWarnings("PHPMD.CouplingBetweenObjects")
  *
  * @FieldWidget(
  *   id = "opening_hours",
@@ -232,7 +232,7 @@ class OpeningHoursWidget extends WidgetBase {
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The form state.
    *
-   * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+   * @SuppressWarnings("PHPMD.CyclomaticComplexity")
    */
   public function validate(array $element, FormStateInterface $form_state): void {
     $serviceElement = $element['service'];

--- a/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php
+++ b/src/Plugin/Field/FieldWidget/OpeningHoursWidget.php
@@ -75,7 +75,7 @@ class OpeningHoursWidget extends WidgetBase {
     array $settings,
     array $third_party_settings,
     ServiceService $serviceService,
-    ChannelService $channelService
+    ChannelService $channelService,
   ) {
     parent::__construct(
       $plugin_id,

--- a/src/Services/SyncService.php
+++ b/src/Services/SyncService.php
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * Service to sync the opening_hours fields with the service/channel data.
  *
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings("PHPMD.CouplingBetweenObjects")
  */
 final class SyncService implements SyncServiceInterface {
 
@@ -216,6 +216,7 @@ final class SyncService implements SyncServiceInterface {
    *   The entity to save.
    */
   protected function syncEntitySave(ContentEntityInterface $entity) {
+    // @phpstan-ignore-next-line
     if ($entity instanceof RevisionableInterface) {
       $entity->setNewRevision(FALSE);
     }

--- a/src/Services/SyncService.php
+++ b/src/Services/SyncService.php
@@ -83,7 +83,7 @@ final class SyncService implements SyncServiceInterface {
     EntityFieldManagerInterface $entityFieldManager,
     ServiceService $serviceService,
     ChannelService $channelService,
-    EventDispatcherInterface $eventDispatcher
+    EventDispatcherInterface $eventDispatcher,
   ) {
     $this->entityTypeManager = $entityTypeManager;
     $this->entityFieldManager = $entityFieldManager;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -154,12 +154,6 @@ setlocale(LC_ALL, 'C');
 // reduce the fragility of the testing system in general.
 date_default_timezone_set('Australia/Sydney');
 
-// Runtime assertions. PHPUnit follows the php.ini assert.active setting for
-// runtime assertions. By default this setting is on. Here we make a call to
-// make PHP 5 and 7 handle assertion failures the same way, but this call does
-// not turn runtime assertions on if they weren't on already.
-assert_options(ASSERT_EXCEPTION, TRUE);
-
 // PHPUnit 4 to PHPUnit 6 bridge. Tests written for PHPUnit 4 need to work on
 // PHPUnit 6 with a minimum of fuss.
 if (version_compare($phpunit_version, '6.1', '>=')) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,7 +9,6 @@
  * @see phpunit.xml.dist
  */
 
-use Drupal\Component\Assertion\Handle;
 use Drupal\Core\Composer\Composer;
 use PHPUnit\Runner\Version;
 
@@ -159,7 +158,7 @@ date_default_timezone_set('Australia/Sydney');
 // runtime assertions. By default this setting is on. Here we make a call to
 // make PHP 5 and 7 handle assertion failures the same way, but this call does
 // not turn runtime assertions on if they weren't on already.
-Handle::register();
+assert_options(ASSERT_EXCEPTION, TRUE);
 
 // PHPUnit 4 to PHPUnit 6 bridge. Tests written for PHPUnit 4 need to work on
 // PHPUnit 6 with a minimum of fuss.


### PR DESCRIPTION
Update code base to add support for Drupal 11 
Remove support for Drupal 9  

https://api.drupal.org/api/drupal/elements/10 


```
orabi@CP122243:~/projects/drupal_site_historischehuizen$ ddev drush upgrade_status:analyze opening_hours
 [notice] Processing /var/www/html/web/modules/contrib/opening_hours.

================================================================================
Opening Hours, --
Scanned on Wed, 03/19/2025 - 10:49

FILE: web/modules/contrib/opening_hours/src/Element/OpeningHoursWidget.php

STATUS         LINE                           MESSAGE
--------------------------------------------------------------------------------
Ignore         15   Class Drupal\opening_hours\Element\OpeningHoursWidget
                    extends deprecated class
                    Drupal\Core\Render\Element\RenderElement. Deprecated in
                    drupal:10.3.0 and is removed from drupal:12.0.0. Use
                    Drupal\Core\Render\Element\RenderElementBase instead.
--------------------------------------------------------------------------------
Ignore         42   Call to method __construct() of deprecated class
                    Drupal\Core\Render\Element\RenderElement. Deprecated in
                    drupal:10.3.0 and is removed from drupal:12.0.0. Use
                    Drupal\Core\Render\Element\RenderElementBase instead.
--------------------------------------------------------------------------------

FILE: web/modules/contrib/opening_hours/tests/bootstrap.php

STATUS         LINE                           MESSAGE
--------------------------------------------------------------------------------
Fix now        162  Call to method register() of deprecated class
                    Drupal\Component\Assertion\Handle. Deprecated in
                    drupal:10.1.0 and is removed from drupal:11.0.0. Use
                    assert_options(ASSERT_EXCEPTION, TRUE).
--------------------------------------------------------------------------------

FILE: web/modules/contrib/opening_hours/opening_hours.info.yml

STATUS         LINE                           MESSAGE
--------------------------------------------------------------------------------
Check manually 7    Value of core_version_requirement: ^9.4 || ^10 is not
                    compatible with the next major version of Drupal core. See
                    https://drupal.org/node/3070687.
--------------------------------------------------------------------------------

FILE: web/modules/contrib/opening_hours/composer.json

STATUS         LINE                           MESSAGE
--------------------------------------------------------------------------------
Check manually 1    The drupal/core requirement is not compatible with the next
                    major version of Drupal. Either remove it or update it to be
                    compatible. See
                    https://www.drupal.org/docs/develop/using-composer/add-a-com
                    poserjson-file#core-compatibility.
--------------------------------------------------------------------------------


 ```